### PR TITLE
Wrap/unwrap element

### DIFF
--- a/can-control.js
+++ b/can-control.js
@@ -14,6 +14,7 @@ var isFunction = require("can-util/js/is-function/is-function");
 var isArray = require("can-util/js/is-array/is-array");
 var each = require("can-util/js/each/each");
 var dev = require("can-util/js/dev/dev");
+var types = require("can-util/js/types/types");
 
 var domData = require("can-util/dom/data/data");
 var className = require("can-util/dom/class-name/class-name");
@@ -169,7 +170,10 @@ var Control = Construct.extend(
 		defaults: {},
         // should be used to overwrite to make nodeLists on this
         convertElement: function(element) {
-            return typeof element === "string" ? document.querySelector(element) : element;
+            element = typeof element === "string" ?
+							document.querySelector(element) : element;
+
+						return types.wrapElement(element);
         },
         // should be overwritten to look in jquery special events
         isSpecial: function(eventName){
@@ -237,7 +241,7 @@ var Control = Construct.extend(
 				var cls = this.constructor,
 					bindings = this._bindings,
 					actions = cls.actions,
-					element = this.element,
+					element = types.unwrapElement(this.element),
 					destroyCB = Control._shifter(this, "destroy"),
 					funcName, ready;
 
@@ -288,7 +292,7 @@ var Control = Construct.extend(
 		// Unbinds all event handlers on the controller.
 		// This should _only_ be called in combination with .on()
 		off: function () {
-			var el = this.element[0],
+			var el = types.unwrapElement(this.element),
 				bindings = this._bindings;
 			if( bindings ) {
 				each(bindings.user || [], function (value) {

--- a/can-control_test.js
+++ b/can-control_test.js
@@ -7,6 +7,7 @@ var dev = require('can-util/js/dev/');
 var domDispatch = require('can-util/dom/dispatch/');
 var domMutate = require('can-util/dom/mutate/');
 var canEvent = require('can-event');
+var types = require("can-util/js/types/types");
 
 QUnit.module('can-control',{
     setup: function(){
@@ -292,3 +293,33 @@ if (dev) {
 		dev.log = oldlog;
 	});
 }
+
+test("Uses types.wrapElement", function(){
+	expect(2);
+	var $ = function(element){
+		this.element = element;
+	};
+
+	var wrapElement = types.wrapElement;
+	var unwrapElement = types.unwrapElement;
+
+	types.wrapElement = function(element){
+		return new $(element);
+	};
+	
+	types.unwrapElement = function(object){
+		return this.element;
+	};
+
+	var MyControl = Control.extend({
+		init: function(element){
+			types.wrapElement = wrapElement;
+			types.unwrapElement = unwrapElement;
+
+			ok(element instanceof $, "element is wrapped");
+			ok(this.element instanceof $, "this.element is wrapped");
+		}
+	});
+
+	new MyControl(document.createElement('div'));
+});

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "npmAlgorithm": "flat"
   },
   "dependencies": {
-    "can-construct": "^3.0.0-pre.1",
+    "can-construct": "^3.0.0-pre.8",
     "can-event": "^3.0.0-pre.1",
-    "can-util": "^3.0.0-pre.21"
+    "can-util": "^3.0.0-pre.34"
   },
   "devDependencies": {
     "bit-docs": "0.0.6",


### PR DESCRIPTION
This calls types.wrapElement in order to set up `this.element` in setup
and calls types.unwrapElement to get the raw element in order to set up
event listeners, etc.

Closes #9