### PR TITLE
Event callbacks should be wrapped

### DIFF
--- a/can-control.js
+++ b/can-control.js
@@ -96,7 +96,6 @@ var Control = Construct.extend(
 		// Moves `this` to the first argument, wraps it with `jQuery` if it's
 		// an element.
 		_shifter: function (context, name) {
-
 			var method = typeof name === "string" ? context[name] : name;
 
 			if (!isFunction(method)) {
@@ -104,8 +103,9 @@ var Control = Construct.extend(
 			}
 
 			return function () {
+				var wrapped = types.wrapElement(this);
 				context.called = name;
-				return method.apply(context, [this].concat(slice.call(arguments, 0)));
+				return method.apply(context, [wrapped].concat(slice.call(arguments, 0)));
 			};
 		},
 

--- a/can-control_test.js
+++ b/can-control_test.js
@@ -295,7 +295,7 @@ if (dev) {
 }
 
 test("Uses types.wrapElement", function(){
-	expect(2);
+	expect(3);
 	var $ = function(element){
 		this.element = element;
 	};
@@ -308,18 +308,24 @@ test("Uses types.wrapElement", function(){
 	};
 	
 	types.unwrapElement = function(object){
-		return this.element;
+		return object.element;
 	};
 
 	var MyControl = Control.extend({
 		init: function(element){
+			ok(element instanceof $, "element is wrapped");
+			ok(this.element instanceof $, "this.element is wrapped");
+		},
+		"click": function(element){
 			types.wrapElement = wrapElement;
 			types.unwrapElement = unwrapElement;
 
-			ok(element instanceof $, "element is wrapped");
-			ok(this.element instanceof $, "this.element is wrapped");
+			ok(element instanceof $);
 		}
 	});
 
-	new MyControl(document.createElement('div'));
+	var el = document.createElement('div');
+	new MyControl(el);
+
+	canEvent.trigger.call(el, "click");
 });


### PR DESCRIPTION
This makes it so when event callbacks are called, the element is first
wrapped. closes #11