### PR TITLE
allowing passing an observable as the options object of the Control constructor

### DIFF
--- a/can-control.js
+++ b/can-control.js
@@ -173,7 +173,7 @@ var Control = Construct.extend(
 
 						// if the parent is not an observable and we don't have a value, show a warning
 						// in this situation, it is not possible for the event handler to be triggered
-						if (!parent || !parent.on && !value) {
+						if (!parent || !types.isMapLike(parent) && !value) {
 							//!steal-remove-start
 							dev.log('can/control/control.js: No property found for handling ' + methodName);
 							//!steal-remove-end
@@ -306,7 +306,16 @@ var Control = Construct.extend(
 			// in [can.Control.prototype.setup setup].
 			//
 			// If no `options` value is used during creation, the value in `defaults` is used instead
-			this.options = assign( assign({}, cls.defaults), options);
+			if (types.isMapLike(options)) {
+				for (var prop in cls.defaults) {
+					if (!options.hasOwnProperty(prop)) {
+						observeReader.set(options, prop, cls.defaults[prop]);
+					}
+				}
+				this.options = options;
+			} else {
+				this.options = assign( assign({}, cls.defaults), options);
+			}
 
 			this.on();
 

--- a/can-control_test.js
+++ b/can-control_test.js
@@ -9,6 +9,7 @@ var domMutate = require('can-util/dom/mutate/');
 var canEvent = require('can-event');
 var types = require("can-util/js/types/types");
 var CanMap = require('can-map');
+var DefineMap = require('can-define/map/');
 
 QUnit.module('can-control',{
     setup: function(){
@@ -392,4 +393,76 @@ test("{element} event handling", function() {
 
 	canEvent.trigger.call(div, "click");
 	canEvent.trigger.call(p, "click");
+});
+
+test("Passing a Map as options works", function() {
+	expect(2);
+	stop();
+
+	var MyControl = Control.extend({
+		defaults: {
+			testEndEvent: 'mouseleave'
+		}
+	}, {
+		'{element} {eventType}': function(){
+			ok(true, 'catches handler from options');
+		},
+		'{element} {testEndEvent}': function(){
+			ok(true, 'catches handler from defaults');
+			start();
+		}
+	});
+	var map = new CanMap({
+		eventType: 'touchstart'
+	});
+
+	var div = document.createElement('div');
+
+	new MyControl(div, map);
+
+	canEvent.trigger.call(div, 'mouseenter');
+
+	map.attr('eventType', 'click');
+
+	canEvent.trigger.call(div, 'click');
+
+	canEvent.trigger.call(div, 'mouseleave');
+});
+
+test("Passing a DefineMap as options works", function() {
+	expect(2);
+	stop();
+
+	var MyControl = Control.extend({
+		defaults: {
+			testEndEvent: 'mouseleave'
+		}
+	}, {
+		'{element} {eventType}': function(){
+			ok(true, 'catches handler from options');
+		},
+		'{element} {testEndEvent}': function(){
+			ok(true, 'catches handler from defaults');
+			start();
+		}
+	});
+	var MyMap = DefineMap.extend({
+		eventType: 'string',
+		testEndEvent: 'string'
+	});
+
+	var map = new MyMap();
+	map.eventType = 'touchstart';
+
+	var div = document.createElement('div');
+
+	new MyControl(div, map);
+
+	canEvent.trigger.call(div, 'mouseenter');
+
+	map.eventType = 'click';
+
+	canEvent.trigger.call(div, 'click');
+
+	canEvent.trigger.call(div, 'mouseleave');
 });

--- a/docs/control.md
+++ b/docs/control.md
@@ -43,8 +43,9 @@ instead, you call it on constructor functions extended from `Control`.
 
 @param {HTMLElement|can-view-nodelist|CSSSelectorString} element Specifies the element the control will be created on.
 
-@param {Object} [options] Option values merged with [can-control.defaults Control.defaults]
-and set as [can-control::options this.options].
+@param {Object|can-map|can-define/map/map} [options] Option values merged with [can-control.defaults Control.defaults]
+and set as [can-control::options this.options]. If options is an observable ([can-map CanMap] / [can-define/map/map DefineMap]), any values from [can-control.defaults defaults] that do not exist on the observable will be set. The observable will then be set as [can-control::options this.options].
+
 
 @return {can-control} A new instance of the constructor function extending Control.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -3,6 +3,7 @@
 @description Options used to configure a control.
 
 @body
+## Options Object
 
 The `this.options` property is an Object that contains
 configuration data passed to a control when it is
@@ -39,3 +40,30 @@ the defaults' message property is used.
 	});
 
 	new Greeting("#greeting");
+
+## Options Observable
+An observable [can-map CanMap] or [can-define/map/map DefineMap] can also be passed instead of an options object.
+
+In the following example, the defaults' message property is set on the [can-define/map/map DefineMap] options observable, which is then set directly as `this.options`:
+
+```
+	var GreetingControl = Control.extend({
+		defaults: {
+			message: 'Hello'
+		}
+	}, {
+		init: function(){
+			this.element.text( this.options.message + ' ' + this.options.name )
+		}
+	});
+
+	var GreetingMap = DefineMap.extend({
+		message: 'string',
+		name: 'string'
+	});
+
+	var data = new GreetingMap();
+	data.name = 'Kevin';
+
+	new GreetingControl('#greeting', data);
+```

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "bit-docs": "0.0.6",
+    "can-define": "^0.8.2",
     "can-map": "^3.0.0-pre.9",
     "cssify": "^1.0.2",
     "done-serve": "^0.2.4",


### PR DESCRIPTION
Closes https://github.com/canjs/can-control/issues/15.