### PR TITLE
skipping dev.warn test in production

### DIFF
--- a/can-control_test.js
+++ b/can-control_test.js
@@ -282,7 +282,8 @@ test("drag and drop events", function() {
 	domDispatch.call(draggable, "drop");
 	domDispatch.call(draggable, "dragend");
 });
-if (dev) {
+
+if (System.env.indexOf('production') < 0) {
 	test('Control is logging information in dev mode', function () {
 		expect(2);
 		var oldlog = dev.log;


### PR DESCRIPTION
Closes https://github.com/canjs/can-control/issues/33.