### PR TITLE
Instance of named control without passing an element

### DIFF
--- a/can-control.js
+++ b/can-control.js
@@ -14,7 +14,7 @@ var isFunction = require("can-util/js/is-function/is-function");
 var each = require("can-util/js/each/each");
 var dev = require("can-util/js/dev/dev");
 var types = require("can-util/js/types/types");
-
+var vDom = require("can-util/dom/document/document");
 var domData = require("can-util/dom/data/data");
 var className = require("can-util/dom/class-name/class-name");
 var domEvents = require("can-util/dom/events/events");
@@ -285,12 +285,12 @@ var Control = Construct.extend(
 			if(!element) {
 				dev.warn('can/control/control.js: Creating an instance of a named control without passing an element');
 
-				element = document.createElement('div');
+				element = vDom().createElement('div');
 			}
 			// Retrieve the raw element, then set the plugin name as a class there.
             this.element = cls.convertElement(element);
 
-			if (element && pluginname && pluginname !== 'can_control') {
+			if (pluginname && pluginname !== 'can_control') {
                 className.add.call(element, pluginname);
 			}
 

--- a/can-control.js
+++ b/can-control.js
@@ -205,7 +205,7 @@ var Control = Construct.extend(
 					};
 				}, this);
 
-				if (controlInstance) {	
+				if (controlInstance) {
 					// Create a handler function that we'll use to handle the `change` event on the `readyCompute`.
 					var handler = function(ev, ready) {
 						// unbinds the old binding
@@ -282,11 +282,15 @@ var Control = Construct.extend(
 				pluginname = cls.pluginName || cls.shortName,
 				arr;
 
-			// Retrieve the raw element, then set the plugin name as a class there.
+			if(!element) {
+				dev.warn('can/control/control.js: Creating an instance of a named control without passing an element');
 
+				element = document.createElement('div');
+			}
+			// Retrieve the raw element, then set the plugin name as a class there.
             this.element = cls.convertElement(element);
 
-			if (pluginname && pluginname !== 'can_control') {
+			if (element && pluginname && pluginname !== 'can_control') {
                 className.add.call(element, pluginname);
 			}
 

--- a/can-control_test.js
+++ b/can-control_test.js
@@ -464,3 +464,11 @@ test("Passing a DefineMap as options works", function() {
 	// trigger event from defaults
 	canEvent.trigger.call(div, 'mouseleave');
 });
+
+test("Creating an instance of a named control without passing an element", function() {
+
+	var MyControl = Control.extend('MyControl');
+	var myControlInstance = new MyControl();
+
+	ok(myControlInstance.element.className === 'MyControl', "Element has the correct class name");
+});


### PR DESCRIPTION
Added support for creating an instance of a named control without passing an element. 