### PR TITLE
Fix #57 destroy test (tempfix)

### DIFF
--- a/can-control_test.js
+++ b/can-control_test.js
@@ -299,7 +299,7 @@ test("beforeremove event", function() {
     }
   });
   var el = fragment('<div id="foo"/>');
-  new Foo(el);  
+  new Foo(el);
   domDispatch.call(el, "beforeremove");
 });
 
@@ -489,28 +489,30 @@ test("Creating an instance of a named control without passing an element", funct
 
 	var MyControl = Control.extend('MyControl');
 	try {
-		new MyControl();	
+		new MyControl();
 	}
 	catch(e) {
 		ok(true, 'Caught an exception');
 	}
-	
+
 });
 
 test("Creating an instance of a named control passing a selector", function() {
 
 	this.fixture.appendChild( fragment('<div id=\'my-control\'>d</div>') );
-	
+
 	var MyControl = Control.extend('MyControl');
 	var myControlInstance = new MyControl('#my-control');
-	
+
 	ok(className.has.call(myControlInstance.element, 'MyControl'), "Element has the correct class name");
 });
 
 test('destroy should not throw when domData is removed (#57)', function () {
 	var Things = Control.extend({
 		destroy: function(){
-			domData.delete.call(this.element);
+      if (this.element) {
+        domData.delete.call(this.element);
+      }
 			Control.prototype.destroy.call(this);
 		}
 	});


### PR DESCRIPTION
With [`can-util` 3.40](https://github.com/canjs/can-util/releases/tag/v3.4.0), the [`can-jquery` tests](https://github.com/canjs/can-jquery/issues/65) [ran `can-control`](https://travis-ci.org/canjs/can-jquery/builds/225322919) which threw an TypeError when `this.element` was null in the test being fixed. This is only a temporary fix. @phillipskevin is working on the [larger problem](https://github.com/canjs/canjs/issues/3147#issuecomment-295903429), which should make everything better.