### PR TITLE
chore(package): update can-define to version 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "can-stache-key": "^0.0.2"
   },
   "devDependencies": {
-    "can-define": "^1.3.0-pre.1",
+    "can-define": "^1.3.3",
     "can-map": "^3.3.1",
     "done-serve": "^0.2.4",
     "jshint": "^2.9.1",


### PR DESCRIPTION
Fixes #75 