### PR TITLE
Hide docs that can’t show up in the navigation

### DIFF
--- a/control.processor.md
+++ b/control.processor.md
@@ -17,3 +17,5 @@ specified by the templated event handler (`"{object}"`).
 @param {can.Control} control The Control the event is bound on.
 
 @return {function()} A callback function that unbinds any event handlers bound within this processor.
+
+@hide

--- a/docs/eventDescription.md
+++ b/docs/eventDescription.md
@@ -3,3 +3,4 @@
 
 @signature `"[CONTEXT ][SELECTOR ]EVENTNAME"`
 
+@hide

--- a/docs/eventHandler.md
+++ b/docs/eventHandler.md
@@ -3,3 +3,4 @@
 
 @signature `function(element, event)`
 
+@hide


### PR DESCRIPTION
Part of https://github.com/canjs/canjs/issues/3660