### PR TITLE
Add new working link for tab example

### DIFF
--- a/docs/control.md
+++ b/docs/control.md
@@ -255,7 +255,7 @@ The selector can also be templated.
 
 Control can also bind to objects other than `this.element` with
 templated event handlers.  This is _critical_
-for avoiding memory leaks that are so common among MVC applications.  
+for avoiding memory leaks that are so common among MVC applications.
 
 If the value inside `{NAME}` is an object, Control will bind to that
 object to listen for events. For example, the following tooltip listens to
@@ -379,7 +379,5 @@ data by calling `$(document.body).empty()`._
 
 Here is an example of how to build a simple tab widget using Control:
 
-<iframe style="width: 100%; height: 300px"
-        src="http://jsfiddle.net/donejs/kXLLt/embedded/result,html,js,css"
-        allowfullscreen="allowfullscreen"
-        frameborder="0">JSFiddle</iframe>
+<p data-height="265" data-theme-id="0" data-slug-hash="eLExWm" data-default-tab="result" data-user="danieltian" data-pen-title="CanJS 5.0 Hello World" class="codepen">See the Pen <a href="https://codepen.io/danieltian/pen/eLExWm/">CanJS 5.0 Hello World</a> by Daniel Tian (<a href="https://codepen.io/danieltian">@danieltian</a>) on <a href="https://codepen.io">CodePen</a>.</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>


### PR DESCRIPTION
The previous tab example is not working properly and uses CanJS 2.0.1:

https://jsfiddle.net/donejs/kXLLt/?utm_source=website&utm_medium=embed&utm_campaign=kXLLt

This PR updates the link to the following CodePen, which uses CanJS@5:

https://codepen.io/danieltian/pen/eLExWm?editors=1010

### Previous:

![previous](https://user-images.githubusercontent.com/123499/45196511-57551680-b1f8-11e8-8759-874990512524.png)

### Current:

![now](https://user-images.githubusercontent.com/123499/45196481-25dc4b00-b1f8-11e8-8749-d3f16b6fd92a.png)
